### PR TITLE
Feature/implement mystery gift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ N64_ROM_REGIONFREE=1
 N64_ROM_CONTROLLER_TYPE1=n64,pak=transfer
 N64_ROM_TITLE="PokeMe64"
 
+# Uncomment this when generating a dev build
+N64_C_AND_CXX_FLAGS += -DDEV_BUILD
+
 SRCS := $(shell find $(SOURCE_DIR) -type f -name '*.cpp')
 OBJS := $(patsubst $(SOURCE_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(SRCS))
 

--- a/include/menu/MenuEntries.h
+++ b/include/menu/MenuEntries.h
@@ -15,8 +15,8 @@ extern const uint32_t gen2MenuEntriesSize;
 extern MenuItemData gen2CrystalMenuEntries[];
 extern const uint32_t gen2CrystalMenuEntriesSize;
 
-extern MenuItemData gen2DecorationMenuEntries[];
-extern const uint32_t gen2DecorationMenuEntriesSize;
+extern MenuItemData gen2MysteryGiftMenuEntries[];
+extern const uint32_t gen2MysteryGiftMenuEntriesSize;
 
 extern MenuItemData backupRestoreMenuEntries[];
 extern const uint32_t backupRestoreMenuEntriesSize;

--- a/include/menu/MenuFunctions.h
+++ b/include/menu/MenuFunctions.h
@@ -6,6 +6,8 @@
 
 #include <cstdint>
 
+//#define PRINT_CLOCK_FUNCTION_ENABLED 1
+
 // these are used to pass as a pointer to the gen1PrepareToTeachPikachu function
 extern const Move MOVE_SURF;
 extern const Move MOVE_FLY;
@@ -125,6 +127,8 @@ void resetRTC(void* context, const void* param);
  */
 void gen2ReceiveMysteryGift(void* context, const void* param);
 
+#ifdef PRINT_CLOCK_FUNCTION_ENABLED
 void printClock(void* context, const void* param);
+#endif
 
 #endif

--- a/include/menu/MenuFunctions.h
+++ b/include/menu/MenuFunctions.h
@@ -116,4 +116,6 @@ void askConfirmationWipeSave(void* context, const void* param);
  */
 void resetRTC(void* context, const void* param);
 
+void printClock(void* context, const void* param);
+
 #endif

--- a/include/menu/MenuFunctions.h
+++ b/include/menu/MenuFunctions.h
@@ -32,7 +32,7 @@ void goToGen1MovesMenu(void* context, const void* param);
 void goToGen1DistributionPokemonMenu(void* context, const void* param);
 void goToGen2DistributionPokemonMenu(void* context, const void* param);
 void goToGen2PCNYDistributionPokemonMenu(void* context, const void* param);
-void goToGen2DecorationMenu(void* context, const void* param);
+void goToGen2MysteryGiftMenu(void* context, const void* param);
 void goToBackupRestoreMenu(void* context, const void* param);
 
 /**
@@ -115,6 +115,15 @@ void askConfirmationWipeSave(void* context, const void* param);
  * @param param a nullpointer (dummy param)
  */
 void resetRTC(void* context, const void* param);
+
+/**
+ * @brief This function will activate the mystery gift functionality.
+ * If the player hasn't hit the 5-gift limit yet, he/she will obtain a random mystery gift
+ *
+ * @param context a MenuScene* context
+ * @param param a nullpointer (dummy param)
+ */
+void gen2ReceiveMysteryGift(void* context, const void* param);
 
 void printClock(void* context, const void* param);
 

--- a/include/scenes/AboutScene.h
+++ b/include/scenes/AboutScene.h
@@ -22,6 +22,7 @@ public:
     void render(RDPQGraphics& gfx, const Rectangle& sceneBounds) override;
 protected:
 private:
+    char headerTextString_[128];
     uint8_t fontIdMainFont_;
     uint8_t fontMainFontStyleWhiteId_;
     sprite_t* logoLibDragon_;

--- a/include/scenes/InitTransferPakScene.h
+++ b/include/scenes/InitTransferPakScene.h
@@ -32,6 +32,7 @@ private:
     void loadSaveMetadata();
     const char* getGameTypeString();
 
+    char pokeMe64String_[48];
     sprite_t* menu9SliceSprite_;
     TransferPakDetectionWidget tpakDetectWidget_;
     WidgetFocusChainSegment tpakDetectWidgetSegment_;

--- a/include/transferpak/TransferPakManager.h
+++ b/include/transferpak/TransferPakManager.h
@@ -55,6 +55,11 @@ public:
     void switchGBROMBank(uint8_t bankIndex);
 
     /**
+     * @brief Returns whether we called setRAMEnabled(true) on this TransferPakManager instance before
+     */
+    bool isRAMEnabled() const;
+
+    /**
      * @brief This function enables/disables gameboy RAM/RTC access.
      * WARNING: it switches to transfer pak bank 0
      */
@@ -110,6 +115,7 @@ protected:
 private:
     joypad_port_t port_;
     bool isPoweredOn_;
+    bool ramEnabled_;
     uint8_t currentSRAMBank_;
     uint16_t readBufferBankOffset_;
     uint16_t writeBufferSRAMBankOffset_;

--- a/include/transferpak/TransferPakRTCReader.h
+++ b/include/transferpak/TransferPakRTCReader.h
@@ -1,0 +1,28 @@
+#ifndef _TRANSFERPAKRTCREADER_H
+#define _TRANSFERPAKRTCREADER_H
+
+#include "RTCReader.h"
+
+class TransferPakManager;
+
+/**
+ * @brief This class implements the IRTCReader interface specifically for the N64 Transfer Pak with libdragon
+ */
+class TransferPakRTCReader : public BaseRTCReader
+{
+public:
+    TransferPakRTCReader(TransferPakManager& tpakManager);
+    virtual ~TransferPakRTCReader();
+
+    /**
+     * This function will grab the current values of the RTC chip and store them internally
+     *
+     * Use the getXYZ() functions to actually retrieve this data
+     */
+    void latch() override;
+protected:
+private:
+    TransferPakManager& tpakManager_;
+};
+
+#endif

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,8 @@
+#ifndef _VERSION_H
+#define _VERSION_H
+
+#define POKEME64_VERSION_NUMBER "0.4"
+
+const char* getPokeMe64VersionString();
+
+#endif

--- a/src/menu/MenuEntries.cpp
+++ b/src/menu/MenuEntries.cpp
@@ -71,6 +71,10 @@ MenuItemData gen2MenuEntries[] = {
         .onConfirmAction = resetRTC
     },
     {
+        .title = "Print Game Clock",
+        .onConfirmAction = printClock
+    },
+    {
         .title = "About",
         .onConfirmAction = goToAboutScene
     }
@@ -106,6 +110,10 @@ MenuItemData gen2CrystalMenuEntries[] = {
     {
         .title = "Reset Game Clock",
         .onConfirmAction = resetRTC
+    },
+    {
+        .title = "Print Game Clock",
+        .onConfirmAction = printClock
     },
     {
         .title = "About",

--- a/src/menu/MenuEntries.cpp
+++ b/src/menu/MenuEntries.cpp
@@ -59,8 +59,8 @@ MenuItemData gen2MenuEntries[] = {
         .onConfirmAction = goToGen2PCNYDistributionPokemonMenu
     },
     {
-        .title = "Unlock Decoration",
-        .onConfirmAction = goToGen2DecorationMenu
+        .title = "Mystery Gift",
+        .onConfirmAction = goToGen2MysteryGiftMenu
     },
     {
         .title = "Gen 3 Transfer Info",
@@ -100,8 +100,8 @@ MenuItemData gen2CrystalMenuEntries[] = {
         .onConfirmAction = gen2ReceiveGSBall
     },
     {
-        .title = "Unlock Decoration",
-        .onConfirmAction = goToGen2DecorationMenu
+        .title = "Mystery Gift",
+        .onConfirmAction = goToGen2MysteryGiftMenu
     },
     {
         .title = "Gen 3 Transfer Info",
@@ -123,25 +123,29 @@ MenuItemData gen2CrystalMenuEntries[] = {
 
 const uint32_t gen2CrystalMenuEntriesSize = sizeof(gen2CrystalMenuEntries);
 
-MenuItemData gen2DecorationMenuEntries[] = {
+MenuItemData gen2MysteryGiftMenuEntries[] = {
     {
-        .title = "Pikachu Bed",
+        .title = "Get Mystery Gift",
+        .onConfirmAction = gen2ReceiveMysteryGift
+    },
+    {
+        .title = "Get Pikachu Bed",
         .onConfirmAction = gen2SetEventFlag,
         .itemParam = &GEN2_EVENTFLAG_DECORATION_PIKACHU_BED
     },
     {
-        .title = "Unown Doll",
+        .title = "Get Unown Doll",
         .onConfirmAction = gen2SetEventFlag,
         .itemParam = &GEN2_EVENTFLAG_DECORATION_UNOWN_DOLL
     },
     {
-        .title = "Tentacool Doll",
+        .title = "Get Tentacool Doll",
         .onConfirmAction = gen2SetEventFlag,
         .itemParam = &GEN2_EVENTFLAG_DECORATION_TENTACOOL_DOLL
     }
 };
 
-const uint32_t gen2DecorationMenuEntriesSize = sizeof(gen2DecorationMenuEntries);
+const uint32_t gen2MysteryGiftMenuEntriesSize = sizeof(gen2MysteryGiftMenuEntries);
 
 MenuItemData backupRestoreMenuEntries[] = {
     {

--- a/src/menu/MenuEntries.cpp
+++ b/src/menu/MenuEntries.cpp
@@ -70,10 +70,12 @@ MenuItemData gen2MenuEntries[] = {
         .title = "Reset Game Clock",
         .onConfirmAction = resetRTC
     },
+#ifdef PRINT_CLOCK_FUNCTION_ENABLED
     {
         .title = "Print Game Clock",
         .onConfirmAction = printClock
     },
+#endif
     {
         .title = "About",
         .onConfirmAction = goToAboutScene
@@ -111,10 +113,12 @@ MenuItemData gen2CrystalMenuEntries[] = {
         .title = "Reset Game Clock",
         .onConfirmAction = resetRTC
     },
+#ifdef PRINT_CLOCK_FUNCTION_ENABLED
     {
         .title = "Print Game Clock",
         .onConfirmAction = printClock
     },
+#endif
     {
         .title = "About",
         .onConfirmAction = goToAboutScene

--- a/src/menu/MenuFunctions.cpp
+++ b/src/menu/MenuFunctions.cpp
@@ -10,6 +10,7 @@
 #include "transferpak/TransferPakManager.h"
 #include "transferpak/TransferPakRomReader.h"
 #include "transferpak/TransferPakSaveManager.h"
+#include "transferpak/TransferPakRTCReader.h"
 
 #define POKEMON_CRYSTAL_ITEM_ID_GS_BALL 0x73
 
@@ -795,13 +796,47 @@ void resetRTC(void* context, const void* param)
     TransferPakManager& tpakManager = scene->getDependencies().tpakManager;
     TransferPakRomReader romReader(tpakManager);
     TransferPakSaveManager saveManager(tpakManager);
+    TransferPakRTCReader rtcReader(tpakManager);
     Gen2GameReader gameReader(romReader, saveManager, gameType, language);
 
     tpakManager.setRAMEnabled(true);
-    gameReader.resetRTC();
+    gameReader.getClockManager(rtcReader).resetRTC();
     tpakManager.finishWrites();
     tpakManager.setRAMEnabled(false);
 
     setDialogDataText(*diag, "The games' clock was reset! Start the game to reconfigure it! Don't forget to save!");
+    scene->showDialog(diag);
+}
+
+void printClock(void* context, const void* param)
+{
+    MenuScene* scene = static_cast<MenuScene*>(context);
+
+    auto diag = new DialogData{
+        .shouldDeleteWhenDone = true
+    };
+
+    if(scene->getDependencies().generation != 2)
+    {
+        setDialogDataText(*diag, "Sorry! This is only supported for Gen 2 Pokémon games!");
+        scene->showDialog(diag);
+        return;
+    }
+
+    const Gen2GameType gameType = static_cast<Gen2GameType>(scene->getDependencies().specificGenVersion);
+    const Gen2LocalizationLanguage language = static_cast<Gen2LocalizationLanguage>(scene->getDependencies().localization);
+    TransferPakManager& tpakManager = scene->getDependencies().tpakManager;
+    TransferPakRomReader romReader(tpakManager);
+    TransferPakSaveManager saveManager(tpakManager);
+    TransferPakRTCReader rtcReader(tpakManager);
+    Gen2GameReader gameReader(romReader, saveManager, gameType, language);
+    Gen2ClockManager clockManager = gameReader.getClockManager(rtcReader);
+
+    tpakManager.setRAMEnabled(true);
+    clockManager.latchRTC();
+    tpakManager.setRAMEnabled(false);
+
+    setDialogDataText(*diag, "The current time is set to %s, %02hhu:%02hhu:%02hhu!\nRTC: %04hx %02hhx %02hhx %02hhx, off: %02hhx %02hhx %02hhx %02hhx", toString(clockManager.getDay()), clockManager.getHours(), clockManager.getMinutes(), clockManager.getSeconds(), rtcReader.getDaysCounter(), rtcReader.getHours(), rtcReader.getMinutes(), rtcReader.getSeconds(), clockManager.getRTCDayOffset(), clockManager.getRTCHourOffset(), clockManager.getRTCMinuteOffset(), clockManager.getRTCSecondOffset());
+
     scene->showDialog(diag);
 }

--- a/src/menu/MenuFunctions.cpp
+++ b/src/menu/MenuFunctions.cpp
@@ -7,6 +7,7 @@
 #include "scenes/SelectFileScene.h"
 #include "scenes/SceneManager.h"
 #include "gen2/Gen2GameReader.h"
+#include "gen2/Gen2Items.h"
 #include "transferpak/TransferPakManager.h"
 #include "transferpak/TransferPakRomReader.h"
 #include "transferpak/TransferPakSaveManager.h"
@@ -219,12 +220,12 @@ void goToGen2PCNYDistributionPokemonMenu(void* context, const void* param)
     goToDistributionPokemonListMenu(context, DistributionPokemonListType::GEN2_POKEMON_CENTER_NEW_YORK);
 }
 
-void goToGen2DecorationMenu(void* context, const void* param)
+void goToGen2MysteryGiftMenu(void* context, const void* param)
 {
     MenuScene* scene = static_cast<MenuScene*>(context);
     auto newSceneContext = new MenuSceneContext{
-        .menuEntries = gen2DecorationMenuEntries,
-        .numMenuEntries = gen2DecorationMenuEntriesSize / sizeof(gen2DecorationMenuEntries[0])
+        .menuEntries = gen2MysteryGiftMenuEntries,
+        .numMenuEntries = gen2MysteryGiftMenuEntriesSize / sizeof(gen2MysteryGiftMenuEntries[0])
     };
 
     scene->getDependencies().sceneManager.switchScene(SceneType::MENU, deleteMenuSceneContext, newSceneContext);
@@ -735,7 +736,28 @@ void gen2SetEventFlag(void* context, const void* param)
     }
     else
     {
+        Gen2MysteryGiftManager mysteryGiftManager = gameReader.getMysteryGiftManager();
         gameReader.setEventFlag(eventFlagIndex, true);
+
+        // For the decoration eventflags, also set the mysterygift decorationsReceived flag.
+        // PokeMe64 has allowed to obtain these 3 decorations directly from the main menu from before version 0.3.
+        // to keep this funtionality intact while also supporting mystery gift, we need to ensure these mystery gift flags are
+        // maintained correctly.
+        switch(eventFlagIndex)
+        {
+            case GEN2_EVENTFLAG_DECORATION_PIKACHU_BED:
+                mysteryGiftManager.setDecorationIDReceivedFlag((uint8_t)Gen2Decoration::PIKACHU_BED);
+                break;
+            case GEN2_EVENTFLAG_DECORATION_TENTACOOL_DOLL:
+                mysteryGiftManager.setDecorationIDReceivedFlag((uint8_t)Gen2Decoration::TENTACOOL_DOLL);
+                break;
+            case GEN2_EVENTFLAG_DECORATION_UNOWN_DOLL:
+                mysteryGiftManager.setDecorationIDReceivedFlag((uint8_t)Gen2Decoration::UNOWN_DOLL);
+                break;
+            default:
+                break;
+        }
+
         gameReader.finishSave();
         tpakManager.finishWrites();
 
@@ -805,6 +827,70 @@ void resetRTC(void* context, const void* param)
     tpakManager.setRAMEnabled(false);
 
     setDialogDataText(*diag, "The games' clock was reset! Start the game to reconfigure it! Don't forget to save!");
+    scene->showDialog(diag);
+}
+
+void gen2ReceiveMysteryGift(void* context, const void* param)
+{
+    MenuScene* scene = static_cast<MenuScene*>(context);
+    const char* trainerName;
+
+    auto diag = new DialogData{
+        .shouldDeleteWhenDone = true
+    };
+
+    if(scene->getDependencies().generation != 2)
+    {
+        setDialogDataText(*diag, "Sorry! This is only supported for Gen 2 Pokémon games!");
+        scene->showDialog(diag);
+        return;
+    }
+
+    const Gen2GameType gameType = static_cast<Gen2GameType>(scene->getDependencies().specificGenVersion);
+    const Gen2LocalizationLanguage language = static_cast<Gen2LocalizationLanguage>(scene->getDependencies().localization);
+    TransferPakManager& tpakManager = scene->getDependencies().tpakManager;
+    TransferPakRomReader romReader(tpakManager);
+    TransferPakSaveManager saveManager(tpakManager);
+    TransferPakRTCReader rtcReader(tpakManager);
+    Gen2GameReader gameReader(romReader, saveManager, gameType, language);
+    Gen2MysteryGiftManager mysteryGiftManager = gameReader.getMysteryGiftManager();
+
+    tpakManager.setRAMEnabled(true);
+    trainerName = gameReader.getTrainerName();
+    if(!mysteryGiftManager.isUnlocked())
+    {
+        mysteryGiftManager.unlock();
+    }
+
+    const MysteryGiftSelection selectedGift = selectRandomGift();
+    MysteryGiftResult result = mysteryGiftManager.obtain(gameReader, rtcReader, selectedGift);
+
+    switch(result)
+    {
+    case MYSTERYGIFT_RESULT_DECORATION:
+        setDialogDataText(*diag, "A %s was transferred to %s's house!", getGen2DecorationString((Gen2Decoration)selectedGift.decorationID), trainerName);
+        break;
+    case MYSTERYGIFT_RESULT_ITEM_ITEMPOCKET:
+        setDialogDataText(*diag, "%s received a %s! %s put the %s in the ITEM POCKET.", trainerName, getGen2ItemString((Gen2Items)selectedGift.itemID), trainerName, getGen2ItemString((Gen2Items)selectedGift.itemID));
+        break;
+    case MYSTERYGIFT_RESULT_ITEM_BALLPOCKET:
+        setDialogDataText(*diag, "%s received a %s! %s put the %s in the BALL POCKET.", trainerName, getGen2ItemString((Gen2Items)selectedGift.itemID), trainerName, getGen2ItemString((Gen2Items)selectedGift.itemID));
+        break;
+    case MYSTERYGIFT_RESULT_ERROR_NOT_UNLOCKED:
+        // should never happen, given that we unlocked it earlier in this function
+        setDialogDataText(*diag, "Sorry! It seems you don't have access to Mystery Gift yet! Unlock it and try again!");
+        break;
+    case MYSTERYGIFT_RESULT_ERROR_TOO_MANY_GIFTS:
+        setDialogDataText(*diag, "Sorry! I'm out of gifts today. Try again tomorrow!");
+        break;
+    case MYSTERYGIFT_RESULT_ERROR_NO_ROOM_FOR_ITEM:
+        setDialogDataText(*diag, "It seems you have no room for the item! Please get rid of an item first!");
+        break;
+    }
+
+    gameReader.finishSave();
+    tpakManager.finishWrites();
+    tpakManager.setRAMEnabled(false);
     scene->showDialog(diag);
 }
 

--- a/src/scenes/AboutScene.cpp
+++ b/src/scenes/AboutScene.cpp
@@ -1,6 +1,7 @@
 #include "scenes/AboutScene.h"
 #include "core/FontManager.h"
 #include "scenes/SceneManager.h"
+#include "version.h"
 
 static const ScrollWidgetStyle scrollWidgetStyle = {
     .scrollStep = 15,
@@ -37,7 +38,7 @@ TESTING/VALIDATION
 MajorUpgrade
 )delim";
 
-static const char* headerTextString = R"delim(PokeMe64 Version 0.3
+static const char* headerTextStringFormat = R"delim(PokeMe64 Version %s
 by risingPhil
 
 SPECIAL THANKS TO:
@@ -46,6 +47,7 @@ SPECIAL THANKS TO:
 
 AboutScene::AboutScene(SceneDependencies& deps, void*)
     : AbstractUIScene(deps)
+    , headerTextString_()
     , fontIdMainFont_(1)
     , fontMainFontStyleWhiteId_(0)
     , logoLibDragon_(nullptr)
@@ -76,6 +78,7 @@ AboutScene::AboutScene(SceneDependencies& deps, void*)
     })
     , bButtonPressed_(false)
 {
+    snprintf(headerTextString_, sizeof(headerTextString_), headerTextStringFormat, getPokeMe64VersionString());
     fontIdMainFont_ = deps.fontManager.getFont("rom://Arial.font64");
 
     const rdpq_fontstyle_t mainFontWhite = {
@@ -129,7 +132,7 @@ void AboutScene::init()
 
     headerText_.setBounds(headerTextBounds);
     headerText_.setStyle(headerTextStyle);
-    headerText_.setData(headerTextString);
+    headerText_.setData(headerTextString_);
     scrollWidget_.addWidget(&headerText_);
 
     const ImageWidgetStyle imgDragonStyle = {

--- a/src/scenes/InitTransferPakScene.cpp
+++ b/src/scenes/InitTransferPakScene.cpp
@@ -7,6 +7,7 @@
 #include "gen1/Gen1GameReader.h"
 #include "gen2/Gen2GameReader.h"
 #include "menu/MenuEntries.h"
+#include "version.h"
 
 #include <unistd.h>
 
@@ -27,6 +28,7 @@ static void tpakWidgetStateChangedCallback(void* context, TransferPakWidgetState
 
 InitTransferPakScene::InitTransferPakScene(SceneDependencies& deps, void*)
     : SceneWithDialogWidget(deps)
+    , pokeMe64String_()
     , menu9SliceSprite_(nullptr)
     , tpakDetectWidget_(deps.animationManager, deps.tpakManager)
     , tpakDetectWidgetSegment_(WidgetFocusChainSegment{
@@ -45,6 +47,8 @@ InitTransferPakScene::~InitTransferPakScene()
 void InitTransferPakScene::init()
 {
     uint8_t systemEntropy[4];
+
+    snprintf(pokeMe64String_, sizeof(pokeMe64String_), "PokeMe64 by risingPhil. Version %s", getPokeMe64VersionString());
     menu9SliceSprite_ = sprite_load("rom://menu-bg-9slice.sprite");
 
     SceneWithDialogWidget::init();
@@ -77,7 +81,7 @@ void InitTransferPakScene::destroy()
 
 void InitTransferPakScene::render(RDPQGraphics& gfx, const Rectangle& sceneBounds)
 {
-    gfx.drawText(Rectangle{0, 10, 320, 16}, "PokeMe64 by risingPhil. Version 0.3", pokeMe64TextSettings_);
+    gfx.drawText(Rectangle{0, 10, 320, 16}, pokeMe64String_, pokeMe64TextSettings_);
     tpakDetectWidget_.render(gfx, sceneBounds);
 
     SceneWithDialogWidget::render(gfx, sceneBounds);

--- a/src/scenes/InitTransferPakScene.cpp
+++ b/src/scenes/InitTransferPakScene.cpp
@@ -4,6 +4,7 @@
 #include "transferpak/TransferPakManager.h"
 #include "transferpak/TransferPakRomReader.h"
 #include "transferpak/TransferPakSaveManager.h"
+#include "transferpak/TransferPakRTCReader.h"
 #include "gen1/Gen1GameReader.h"
 #include "gen2/Gen2GameReader.h"
 #include "menu/MenuEntries.h"
@@ -288,6 +289,7 @@ void InitTransferPakScene::loadSaveMetadata()
 {
     TransferPakRomReader romReader(deps_.tpakManager);
     TransferPakSaveManager saveManager(deps_.tpakManager);
+    TransferPakRTCReader rtcReader(deps_.tpakManager);
     Gen1GameType gen1Type;
     Gen2GameType gen2Type;
     uint16_t trainerID = 0;
@@ -307,8 +309,16 @@ void InitTransferPakScene::loadSaveMetadata()
     else if(gen2Type != Gen2GameType::INVALID)
     {
         const Gen2LocalizationLanguage language = gen2_determineGameLanguage(romReader, gen2Type);
-
         Gen2GameReader gameReader(romReader, saveManager, gen2Type, language);
+        Gen2ClockManager clockManager = gameReader.getClockManager(rtcReader);
+
+        // add more entropy to the randomSeed by adding the current daycounter + time to it.
+        clockManager.latchRTC();
+        randomSeed_ += (static_cast<unsigned int>(clockManager.getDayCounter() & 0xFF) << 24);
+        randomSeed_ += (static_cast<unsigned int>(clockManager.getHours()) << 16);
+        randomSeed_ += (static_cast<unsigned int>(clockManager.getMinutes()) << 8);
+        randomSeed_ += static_cast<unsigned int>(clockManager.getSeconds());
+
         const char* trainerName = gameReader.getTrainerName();
         trainerID = gameReader.getTrainerID();
         deps_.localization = static_cast<uint8_t>(language);

--- a/src/transferpak/TransferPakManager.cpp
+++ b/src/transferpak/TransferPakManager.cpp
@@ -11,6 +11,7 @@ static const uint16_t sramBankStartGBAddress = 0xA000;
 TransferPakManager::TransferPakManager()
     : port_(JOYPAD_PORT_1)
     , isPoweredOn_(false)
+    , ramEnabled_(false)
     , currentSRAMBank_(0)
     , readBufferBankOffset_(0xFFFF)
     , writeBufferSRAMBankOffset_(0xFFFF)
@@ -139,6 +140,11 @@ void TransferPakManager::switchGBROMBank(uint8_t bankIndex)
     readBufferBankOffset_ = 0xFFFF;
 }
 
+bool TransferPakManager::isRAMEnabled() const
+{
+    return ramEnabled_;
+}
+
 void TransferPakManager::setRAMEnabled(bool enabled)
 {
     uint8_t data[TPAK_BLOCK_SIZE];
@@ -157,6 +163,7 @@ void TransferPakManager::setRAMEnabled(bool enabled)
         debugf("[TransferPakManager]: %s: ERROR: transfer pak not ready yet. Current status is %hu\r\n", __FUNCTION__, status);
         status = getStatus();
     }
+    ramEnabled_ = enabled;
 }
 
 void TransferPakManager::switchGBSRAMBank(uint8_t bankIndex)

--- a/src/transferpak/TransferPakRTCReader.cpp
+++ b/src/transferpak/TransferPakRTCReader.cpp
@@ -1,0 +1,57 @@
+#include "transferpak/TransferPakRTCReader.h"
+#include "transferpak/TransferPakManager.h"
+
+TransferPakRTCReader::TransferPakRTCReader(TransferPakManager& tpakManager)
+    : tpakManager_(tpakManager)
+{
+}
+
+TransferPakRTCReader::~TransferPakRTCReader()
+{
+}
+
+void TransferPakRTCReader::latch()
+{
+    uint8_t data[TPAK_BLOCK_SIZE];
+    const int port = tpakManager_.getPort();
+
+    // enable SRAM and RTC first
+    const bool previousRAMState = tpakManager_.isRAMEnabled();
+    tpakManager_.setRAMEnabled(true);
+    tpakManager_.finishWrites();
+
+    // now latch the RTC data into the RTC registers
+    // https://gbdev.io/pandocs/MBC3.html
+    memset(data, 0, sizeof(data));
+    tpak_write(port, 0x6000, data, TPAK_BLOCK_SIZE);
+    memset(data, 1, sizeof(data));
+    tpak_write(port, 0x6000, data, TPAK_BLOCK_SIZE);
+
+    // RTC S (seconds)
+    tpakManager_.switchGBSRAMBank(0x08);
+    tpak_read(port, 0xA000, data, sizeof(data));
+    seconds_ = data[0];
+
+    // RTC M (minutes)
+    tpakManager_.switchGBSRAMBank(0x09);
+    tpak_read(port, 0xA000, data, sizeof(data));
+    minutes_ = data[0];
+
+    // RTC H (hours)
+    tpakManager_.switchGBSRAMBank(0x0A);
+    tpak_read(port, 0xA000, data, sizeof(data));
+    hours_ = data[0];
+
+    // RTC DH (days counter upper 8 bits)
+    tpakManager_.switchGBSRAMBank(0x0C);
+    tpak_read(port, 0xA000, data, sizeof(data));
+    daysRaw_ = data[0];
+    daysRaw_ <<= 8;
+
+    // RTC DL (days counter lower 8 bits)
+    tpakManager_.switchGBSRAMBank(0x0B);
+    tpak_read(port, 0xA000, data, sizeof(data));
+    daysRaw_ |= data[0];
+
+    tpakManager_.setRAMEnabled(previousRAMState);
+}

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,0 +1,52 @@
+#include "version.h"
+
+#include <cstring>
+#include <cstdio>
+#include <cstdint>
+
+#ifdef DEV_BUILD
+static const char DEV_SUFFIX_STRING[] = "-dev";
+
+static const char *months[] = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+};
+
+static uint8_t get_month_number(const char *month)
+{
+    for (uint8_t i = 0; i < 12; ++i)
+    {
+        if (strcmp(month, months[i]) == 0)
+        {
+            return i + 1;
+        }
+    }
+    return 0; // Should never happen
+}
+#endif
+
+const char* getPokeMe64VersionString()
+{
+    static char versionString[20];
+
+    memcpy(versionString, POKEME64_VERSION_NUMBER, sizeof(POKEME64_VERSION_NUMBER));
+
+#ifdef DEV_BUILD
+    size_t currentStringLength;
+    char month[4];
+    uint16_t year;
+    int day;
+    uint8_t monthNumber;
+
+    strcat(versionString, DEV_SUFFIX_STRING);
+    // -2 to not count the null terminators
+    currentStringLength = sizeof(POKEME64_VERSION_NUMBER) + sizeof(DEV_SUFFIX_STRING) - 2;
+
+    // Parse __DATE__ ("MMM DD YYYY")
+    // We can't use strptime() because libdragon doesn't appear to have it.
+    sscanf(__DATE__, "%3s %d %hu", month, &day, &year);
+    monthNumber = get_month_number(month);
+    snprintf(versionString + currentStringLength, sizeof(versionString) - currentStringLength, "%04hu%02hhu%02d", year, monthNumber, day);
+#endif
+    return versionString;
+}


### PR DESCRIPTION
This pull request implements mystery gift in PokeMe64.

I think it was [/u/CoochieWrecker](https://www.reddit.com/user/Coochie-Wrecker/) who suggested this as a feature for PokeMe64 to avoid the usual restrictions based on trainer ID.

PokeMe64 allows you to get 5 mystery gifts per day, but it will fill all mystery gift slots for that day, meaning that if you get all 5, you won't be able to get any more through stadium 2 or other gameboys either for that day.